### PR TITLE
separate check jobs to run in parallel

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,3 +11,5 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version-file: .python-version
+    - name: Setup Just
+      uses: extractions/setup-just@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,35 +8,54 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
-  setup:
+   
+  check-code:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./ .github/actions/setup
-      - uses: extractions/setup-just@v3
+      - uses: ./.github/actions/setup
       - run: uv sync --group=check
-  check-code:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
+
       - run: uv run just check-code
   check-format:
-    needs: setup
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: uv sync --group=check
+
       - run: uv run just check-format
   check-type:
-    needs: setup
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+
       - run: uv add --dev ty
+      - run: "echo 'WARNING: ty is being used for type checking. Ty is not production ready.'"
       - run: uv run just check-type
   check-coverage:
-    needs: setup, check-code
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      
+      - name: Install pytest
+        run: uv add --dev pytest pytest-cov
+
       - name: Check coverage
-      - run: uv run just check-coverage
+        run: uv run just check-coverage
+  
+  coverage-comment:
+    needs: 
+      - check-coverage
+      - check-code
+      - check-format
+      - check-type
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - '*'
   workflow_dispatch:
+  push:
+    branches:
+      - '*'
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -45,6 +48,12 @@ jobs:
 
       - name: Check coverage
         run: uv run just check-coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
   
   coverage-comment:
     needs: 
@@ -55,6 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
 
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,19 +8,35 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
-  checks:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
+      - uses: ./ .github/actions/setup
       - uses: extractions/setup-just@v3
-      - run: uv add --dev ty
       - run: uv sync --group=check
+  check-code:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
       - run: uv run just check-code
+  check-format:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
       - run: uv run just check-format
-      - run: uv run just check-coverage
+  check-type:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - run: uv add --dev ty
       - run: uv run just check-type
-      
+  check-coverage:
+    needs: setup, check-code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check coverage
+      - run: uv run just check-coverage
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,7 +56,9 @@ jobs:
           path: coverage.xml
   
   coverage-comment:
-    needs: 
+    permissions:
+      pull-requests: write
+    needs:
       - check-coverage
       - check-code
       - check-format


### PR DESCRIPTION
fix #5 
All check jobs are running in parallel. The coverage comment is only produced if all checks pass.